### PR TITLE
Update gtk.cpp

### DIFF
--- a/src/gtk.cpp
+++ b/src/gtk.cpp
@@ -11,4 +11,5 @@ void Gtk::setGtk(QString gtkTheme)
     interface = new QDBusInterface("org.kde.GtkConfig", "/GtkConfig", "org.kde.GtkConfig", *bus);
     interface->call("setGtk2Theme", gtkTheme);
     interface->call("setGtk3Theme", gtkTheme);
+    interface->call("setGtkTheme", gtkTheme);
 }


### PR DESCRIPTION
The qdbus method setGtkTheme2/setGtkTheme3 was renamed to setGtkTheme in KDE 5.19.90/5.20.0
https://github.com/baduhai/Koi/issues/29#issuecomment-727813991